### PR TITLE
Add defschema macro and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,29 @@ defmodule MyApp.SomeController do
 end
 ```
 
+### Using the defschema Macro
+
+```elixir
+defmodule MyApp.SomeController do
+  import Goal
+  import Goal.Syntax
+
+  def create(conn, params) do
+    with {:ok, attrs} <- validate_params(params, schema()) do
+      ...
+    end
+  end
+
+  defp schema do
+    defschema do
+      required :uuid, :string, format: :uuid
+      required :name, :string, min: 3, max: 3
+      optional :age, :integer
+    end
+  end
+end
+```
+
 ## Features
 
 ### Defining validations

--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -1,9 +1,9 @@
 defmodule Goal do
   @moduledoc ~S"""
-  Validate parameters using a rules schema.
+  Goal contains functions to validate parameters using a rules schema.
 
-  The parameters can be any map, and can be string-based or atom-based. Goal uses the validation
-  rules from in `Ecto.Changeset`, which means you can use any validation that is available for
+  The parameters can be any map, be it string-based or atom-based. Goal uses the validation
+  rules from `Ecto.Changeset`, which means you can use any validation that is available for
   database fields for validating parameters with Goal.
 
   A common use-case is parsing and validating parameters from Phoenix controllers:

--- a/lib/goal/syntax.ex
+++ b/lib/goal/syntax.ex
@@ -1,0 +1,74 @@
+defmodule Goal.Syntax do
+  @moduledoc """
+  Goal.Syntax provides the `defschema` macro to define schemas.
+
+  ## Usage
+
+  ```elixir
+  import Goal.Syntax
+  ```
+  """
+
+  @doc """
+  Transforms the schema into a validation schema.
+
+  ```elixir
+  import Goal.Syntax
+
+  defp schema do
+    defschema do
+      required :id, :string, format: :uuid
+      required :name, :string
+      optional :age, :integer, min: 0, max: 120
+      optional :gender, :enum, values: ["female", "male", "non-binary"]
+    end
+  end
+  ```
+  """
+  @spec defschema(do: {:__block__, any, any}) :: any
+  defmacro defschema(do: block) do
+    block
+    |> generate_schema()
+    |> Macro.escape()
+  end
+
+  defp generate_schema({:__block__, _lines, contents}) do
+    Enum.reduce(contents, %{}, fn function, acc ->
+      Map.merge(acc, generate_schema(function))
+    end)
+  end
+
+  defp generate_schema({:optional, _lines, [field, type]}) do
+    %{field => [{:type, type}]}
+  end
+
+  defp generate_schema({:optional, _lines, [field, type, options]}) do
+    if block_or_function = Keyword.get(options, :do) do
+      properties = generate_schema(block_or_function)
+      clean_options = Keyword.delete(options, :do)
+
+      %{field => [{:type, type} | [{:properties, properties} | clean_options]]}
+    else
+      %{field => [{:type, type} | options]}
+    end
+  end
+
+  defp generate_schema({:required, _lines, [field, type]}) do
+    %{field => [{:type, type}, {:required, true}]}
+  end
+
+  defp generate_schema({:required, _lines, [field, type, options]}) do
+    if block_or_function = Keyword.get(options, :do) do
+      properties = generate_schema(block_or_function)
+      clean_options = Keyword.delete(options, :do)
+
+      %{
+        field => [
+          {:type, type} | [{:required, true} | [{:properties, properties} | clean_options]]
+        ]
+      }
+    else
+      %{field => [{:type, type} | [{:required, true} | options]]}
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Goal.MixProject do
   use Mix.Project
 
-  @version "0.0.1"
+  @version "0.1.0"
   @source_url "https://github.com/martinthenth/goal"
 
   def project do

--- a/test/goal/syntax_test.exs
+++ b/test/goal/syntax_test.exs
@@ -1,0 +1,94 @@
+defmodule Goal.SyntaxTest do
+  use ExUnit.Case
+
+  import Goal.Syntax
+
+  describe "define schema" do
+    test "valid example" do
+      schema =
+        defschema do
+          required(:id, :integer)
+          required(:uuid, :string, format: :uuid)
+          required(:name, :string, min: 3, max: 20)
+          optional(:type, :string, squish: true)
+          optional(:age, :integer, min: 0, max: 120)
+          optional(:gender, :enum, values: ["female", "male", "non-binary"])
+
+          required :car, :map do
+            optional(:name, :string, min: 3, max: 20)
+            optional(:brand, :string, included: ["Mercedes", "GMC"])
+
+            required :stats, :map do
+              optional(:age, :integer)
+              optional(:mileage, :float)
+              optional(:color, :string, excluded: ["camo"])
+            end
+
+            optional(:deleted, :boolean)
+          end
+
+          required :dogs, {:array, :map} do
+            optional(:name, :string)
+            optional(:age, :integer)
+            optional(:type, :string)
+
+            required :data, :map do
+              optional(:paws, :integer)
+            end
+          end
+        end
+
+      assert schema == %{
+               id: [type: :integer, required: true],
+               uuid: [type: :string, required: true, format: :uuid],
+               name: [type: :string, required: true, min: 3, max: 20],
+               type: [type: :string, squish: true],
+               age: [type: :integer, min: 0, max: 120],
+               gender: [type: :enum, values: ["female", "male", "non-binary"]],
+               car: [
+                 type: :map,
+                 required: true,
+                 properties: %{
+                   name: [type: :string, min: 3, max: 20],
+                   brand: [type: :string, included: ["Mercedes", "GMC"]],
+                   stats: [
+                     type: :map,
+                     required: true,
+                     properties: %{
+                       age: [type: :integer],
+                       mileage: [type: :float],
+                       color: [type: :string, excluded: ["camo"]]
+                     }
+                   ],
+                   deleted: [type: :boolean]
+                 }
+               ],
+               dogs: [
+                 type: {:array, :map},
+                 required: true,
+                 properties: %{
+                   name: [type: :string],
+                   age: [type: :integer],
+                   type: [type: :string],
+                   data: [
+                     type: :map,
+                     required: true,
+                     properties: %{
+                       paws: [type: :integer]
+                     }
+                   ]
+                 }
+               ]
+             }
+    end
+
+    test "single entry" do
+      schema =
+        defschema do
+          required(:id, :integer)
+        end
+
+      assert schema == %{id: [type: :integer, required: true]}
+    end
+  end
+end


### PR DESCRIPTION
- Adds the `defschema` macro for defining validation schemas without all the boilerplate.