### PR TITLE
Allow number validations for all number types, refactor the validation logic, and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 No breaking changes.
 
+- Allow number validations for all number fields (incl. `:decimal`, `:float`, etc.)
 - Adds performance optimizations to the validation logic
 - Adds tests to confirm `traverse_errors/2` doesn't break embedded Ecto schemas
 - Refactors the validation logic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 No breaking changes.
 
-- Allow number validations for all number fields (incl. `:decimal`, `:float`, etc.)
+- Allow number validations for all number fields (incl. `:decimal`, `:float`)
 - Adds performance optimizations to the validation logic
 - Adds tests to confirm `traverse_errors/2` doesn't break embedded Ecto schemas
 - Refactors the validation logic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
+# 0.1.1
+
+No breaking changes.
+
+- Adds performance optimizations to the validation logic
+- Adds tests to confirm `traverse_errors/2` doesn't break embedded Ecto schemas
+- Refactors the validation logic
+- Updates documentation
+
 # 0.1.0
 
-- Add `defschema` macro for defining validation schemas with less boilerplate
+No breaking changes.
+
+- Adds `defschema` macro for defining validation schemas with less boilerplate
 
 # 0.0.1
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Goal ⚽
 
-A library for parsing and validating parameters. It takes the `params` (e.g. from an Phoenix controller action), validates them against a schema, and returns an atom-based map or an error changeset. It's based on [Ecto](https://github.com/elixir-ecto/ecto), so every validation that you have for database fields can be applied in validating parameters.
+A library for parsing and validating parameters. Goal takes the `params` (e.g. from an Phoenix controller), validates them against a schema, and returns an atom-based map or an error changeset. It's based on [Ecto](https://github.com/elixir-ecto/ecto), so every validation that you have for database fields can be applied in validating parameters.
 
-Goal is different from other validation libraries because of its syntax, it being Ecto-based, and it validates data using pure functions instead of building embedded `Ecto.Schema` in the background.
+Goal is different from other validation libraries because of its syntax, being Ecto-based, and validating data using functions from `Ecto.Changeset` instead of building embedded `Ecto.Schema`s in the background.
 
-Goal allows you to configure your own regexes. This is helpful in case of backward compatibility, where Goal's defaults might not match your production system's regexes.
+Additionally, Goal allows you to configure your own regexes. This is helpful in case of backward compatibility, where Goal's defaults might not match your production system's behavior.
 
 ## Installation
 
@@ -13,56 +13,14 @@ Add `goal` to the list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:goal, "~> 0.1.0"}
+    {:goal, "~> 0.1.1"}
   ]
 end
 ```
 
 ## Usage
 
-There are several patterns you can choose to validate parameters using Goal.
-
-### Using module attributes
-
-```elixir
-defmodule MyApp.SomeController do
-  import Goal
-
-  @schema %{
-    id: [format: :uuid, required: true],
-    name: [min: 3, max: 20, required: true]
-  }
-
-  def create(conn, params) do
-    with {:ok, attrs} <- validate_params(params, @schema) do
-      ...
-    end
-  end
-end
-```
-
-### Using private functions
-
-```elixir
-defmodule MyApp.SomeController do
-  import Goal
-
-  def create(conn, params) do
-    with {:ok, attrs} <- validate_params(params, schema()) do
-      ...
-    end
-  end
-
-  defp schema do
-    %{
-      id: [format: :uuid, required: true],
-      name: [min: 3, max: 20, required: true]
-    }
-  end
-end
-```
-
-### Using the defschema Macro
+Goal's entry point is `Goal.validate_params/2`, which receives the parameters and a validation schema. The parameters must be a map, and can be string-based or atom-based. Goal needs a validation schema (also a map) to parse and validate the parameters. You can build one with the `defschema` macro:
 
 ```elixir
 defmodule MyApp.SomeController do
@@ -79,7 +37,43 @@ defmodule MyApp.SomeController do
     defschema do
       required :uuid, :string, format: :uuid
       required :name, :string, min: 3, max: 3
-      optional :age, :integer
+      optional :age, :integer, min: 0, max: 120
+      optional :gender, :enum, values: ["female", "male", "non-binary"]
+
+      optional :data, :map do
+        required :color, :string
+        optional :money, :decimal
+        optional :height, :float
+      end
+    end
+  end
+end
+```
+
+The `defschema` macro converts the given structure into a validation schema at compile-time. You can also use the basic syntax like in the example below. The basic syntax is what `defschema` compiles to.
+
+```elixir
+defmodule MyApp.SomeController do
+  import Goal
+
+  @schema %{
+    id: [format: :uuid, required: true],
+    name: [min: 3, max: 20, required: true],
+    age: [type: :integer, min: 0, max: 120],
+    gender: [type: :enum, values: ["female", "male", "non-binary"]],
+    data: [
+      type: :map,
+      properties: %{
+        color: [required: true],
+        money: [type: :decimal],
+        height: [type: :float]
+      }
+    ]
+  }
+
+  def create(conn, params) do
+    with {:ok, attrs} <- validate_params(params, @schema) do
+      ...
     end
   end
 end
@@ -87,51 +81,9 @@ end
 
 ## Features
 
-### Defining validations
-
-Define field types with `:type`:
-
-- `:string`
-- `:integer`
-- `:boolean`
-- `:float`
-- `:decimal`
-- `:date`
-- `:time`
-- `:map`
-- `{:array, inner_type}`, where `inner_type` can be any of the field types
-- See [Ecto.Schema](https://hexdocs.pm/ecto/Ecto.Schema.html#module-primitive-types) for the full list
-
-The default field type is `:string`. That means you don't have to define this field in the schema
-if the value will be a string.
-
-Define map fields with `:properties`.
-
-Define string validations:
-
-- `:equals`, string value
-- `:is`, string length
-- `:min`, minimum string length
-- `:max`, maximum string length
-- `:trim`, boolean to remove leading and trailing spaces
-- `:squish`, boolean to trim and collapse spaces
-- `:format`, atom to define the regex (available are: `:uuid`, `:email`, `:password`, `:url`)
-
-Define integer validations:
-
-- `:is`, integer value
-- `:min`, minimum integer value
-- `:max`, maximum integer value
-- `:greater_than`, minimum integer value
-- `:less_than`, maximum integer value
-- `:greater_than_or_equal_to`, minimum integer value
-- `:less_than_or_equal_to`, maximum integer value
-- `:equal_to`, integer value
-- `:not_equal_to`, integer value
-
 ### Bring your own regex
 
-Goal has sensible defaults for string format validation. If you'd like to use your own regex, e.g. for validating email addresses or passwords, you can add your own regex in the configuration.
+Goal has sensible defaults for string format validation. If you'd like to use your own regex, e.g. for validating email addresses or passwords, then you can add your own regex in the configuration:
 
 ```elixir
 config :goal,
@@ -143,7 +95,7 @@ config :goal,
 
 ### Deeply nested maps
 
-Goal efficiently builds error changesets for nested maps. There is no limitation on depth. If the schema is becoming too verbose, you could consider splitting up the schema into reusable components.
+Goal efficiently builds error changesets for nested maps, and has support for lists of nested maps. There is no limitation on depth.
 
 ```elixir
 params = %{
@@ -181,10 +133,10 @@ iex(3)> Goal.validate_params(params, schema)
 {:ok, %{nested_map: %{inner_map: %{map: %{id: 123, list: [1, 2, 3]}}}}}
 ```
 
-### Using defschema to reduce boilerplate
+### Use defschema to reduce boilerplate
 
 Goal provides a macro called `Goal.Syntax.defschema/1` to build validation schemas without all
-the boilerplate code. The previous example of deeply nested maps can be rewritten as:
+the boilerplate code. The previous example of deeply nested maps can be rewritten to:
 
 ```elixir
 import Goal.Syntax
@@ -207,15 +159,59 @@ iex(3)> Goal.validate_params(params, schema)
 {:ok, %{nested_map: %{inner_map: %{map: %{id: 123, list: [1, 2, 3]}}}}}
 ```
 
-### Human-readable error messages
+### Readable error messages
 
-Use `Goal.traverse_errors/2` to build readable errors. Ecto and Phoenix by default use `Ecto.Changeset.traverse_errors/2`, which works for embedded Ecto schemas but not for the plain nested maps used by Goal.
+Use `Goal.traverse_errors/2` to build readable errors. Phoenix by default uses `Ecto.Changeset.traverse_errors/2`, which works for embedded Ecto schemas but not for the plain nested maps used by Goal. Goal's `traverse_errors/2` is compatible with (embedded) `Ecto.Schema`s, so you don't have to make any changes to your existing logic.
 
 ```elixir
 def translate_errors(changeset) do
   Goal.traverse_errors(changeset, &translate_error/1)
 end
 ```
+
+### Available validations
+
+The field types and available validations are:
+
+| Field type             | Validations                 | Description                                                                                          |
+| ---------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `:string`              | `:equals`                   | string value                                                                                         |
+|                        | `:is`                       | string length                                                                                        |
+|                        | `:min`                      | minimum string length                                                                                |
+|                        | `:max`                      | maximum string length                                                                                |
+|                        | `:trim`                     | oolean to remove leading and trailing spaces                                                         |
+|                        | `:squish`                   | boolean to trim and collapse spaces                                                                  |
+|                        | `:format`                   | `:uuid`, `:email`, `:password`, `:url`                                                               |
+|                        | `:subset`                   | list of required strings                                                                             |
+|                        | `:included`                 | list of allowed strings                                                                              |
+|                        | `:excluded`                 | list of disallowed strings                                                                           |
+| `:integer`             | `:equals`                   | integer value                                                                                        |
+|                        | `:is`                       | integer value                                                                                        |
+|                        | `:min`                      | minimum integer value                                                                                |
+|                        | `:max`                      | maximum integer value                                                                                |
+|                        | `:greater_than`             | minimum integer value                                                                                |
+|                        | `:less_than`                | maximum integer value                                                                                |
+|                        | `:greater_than_or_equal_to` | minimum integer value                                                                                |
+|                        | `:less_than_or_equal_to`    | maximum integer value                                                                                |
+|                        | `:equal_to`                 | integer value                                                                                        |
+|                        | `:not_equal_to`             | integer value                                                                                        |
+|                        | `:subset`                   | list of required integers                                                                            |
+|                        | `:included`                 | list of allowed integers                                                                             |
+|                        | `:excluded`                 | list of disallowed integers                                                                          |
+| `:float`               |                             | all of the integer validations                                                                       |
+| `:decimal`             |                             | all of the integer validations                                                                       |
+| `:boolean`             | `:equals`                   | boolean value                                                                                        |
+| `:date`                | `:equals`                   | date value                                                                                           |
+| `:time`                | `:equals`                   | time value                                                                                           |
+| `:enum`                | `:values`                   | list of allowed values                                                                               |
+| `:map`                 | `:properties`               | use `:properties` to define the fields                                                               |
+| `{:array, :map}`       | `:properties`               | use `:properties` to define the fields                                                               |
+| `{:array, inner_type}` |                             | `inner_type` can be any of the basic types                                                           |
+| More basic types       |                             | See [Ecto.Schema](https://hexdocs.pm/ecto/Ecto.Schema.html#module-primitive-types) for the full list |
+
+The default basic type is `:string`. You don't have to define this field if you are using the basic syntax.
+
+All field types, exluding `:map` and `{:array, :map}`, can use `:equals`, `:subset`, `:included`, `:excluded` validations.
 
 ## Roadmap
 

--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -237,7 +237,7 @@ defmodule Goal do
   @type error :: {String.t(), Keyword.t()}
 
   @doc ~S"""
-  Validates the parameters against a schema.
+  Validates parameters against a schema.
 
   ## Examples
 
@@ -338,23 +338,23 @@ defmodule Goal do
       {:is, integer}, acc ->
         change = get_in(acc, [Access.key(:changes), Access.key(field)])
 
-        if is_integer(change),
-          do: validate_number(acc, field, equal_to: integer),
-          else: validate_length(acc, field, is: integer)
+        if is_binary(change),
+          do: validate_length(acc, field, is: integer),
+          else: validate_number(acc, field, equal_to: integer)
 
       {:min, integer}, acc ->
         change = get_in(acc, [Access.key(:changes), Access.key(field)])
 
-        if is_integer(change),
-          do: validate_number(acc, field, greater_than_or_equal_to: integer),
-          else: validate_length(acc, field, min: integer)
+        if is_binary(change),
+          do: validate_length(acc, field, min: integer),
+          else: validate_number(acc, field, greater_than_or_equal_to: integer)
 
       {:max, integer}, acc ->
         change = get_in(acc, [Access.key(:changes), Access.key(field)])
 
-        if is_integer(change),
-          do: validate_number(acc, field, less_than_or_equal_to: integer),
-          else: validate_length(acc, field, max: integer)
+        if is_binary(change),
+          do: validate_length(acc, field, max: integer),
+          else: validate_number(acc, field, less_than_or_equal_to: integer)
 
       {:trim, true}, acc ->
         update_change(acc, field, &String.trim/1)

--- a/lib/goal/syntax.ex
+++ b/lib/goal/syntax.ex
@@ -1,6 +1,6 @@
 defmodule Goal.Syntax do
   @moduledoc """
-  Goal.Syntax provides the `defschema` macro to define schemas.
+  Goal.Syntax provides the `defschema` macro for defining validation schemas.
 
   ## Usage
 
@@ -10,7 +10,7 @@ defmodule Goal.Syntax do
   """
 
   @doc """
-  A macro for defining validation schemas.
+  A macro for defining validation schemas that are generated at compile-time.
 
   ```elixir
   import Goal.Syntax
@@ -21,6 +21,11 @@ defmodule Goal.Syntax do
       required :name, :string
       optional :age, :integer, min: 0, max: 120
       optional :gender, :enum, values: ["female", "male", "non-binary"]
+
+      required :data, :map do
+        required :city, :string
+        optional :birthday, :date
+      end
     end
   end
   ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Goal.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
   @source_url "https://github.com/martinthenth/goal"
   @changelog_url "https://github.com/martinthenth/goal/blob/main/CHANGELOG.md"
 

--- a/test/goal/changeset_test.exs
+++ b/test/goal/changeset_test.exs
@@ -1,0 +1,33 @@
+defmodule Goal.ChangesetTest do
+  use ExUnit.Case
+
+  import Goal.Helpers
+
+  alias Goal.DemoSchema
+
+  describe "traverse_errors/2" do
+    test "missing required fields, doesn't break embedded schemas" do
+      data = %{}
+      changeset = DemoSchema.changeset(data)
+
+      assert errors_on(changeset) == %{
+               age: ["can't be blank"],
+               embedded_demo: ["can't be blank"],
+               name: ["can't be blank"]
+             }
+    end
+
+    test "missing required embedded fields, doesn't break embedded schemas" do
+      data = %{name: "Name", age: 65, embedded_demo: %{}}
+
+      changeset = DemoSchema.changeset(data)
+
+      assert errors_on(changeset) == %{
+               embedded_demo: %{
+                 age: ["can't be blank"],
+                 name: ["can't be blank"]
+               }
+             }
+    end
+  end
+end

--- a/test/goal/syntax_test.exs
+++ b/test/goal/syntax_test.exs
@@ -3,7 +3,7 @@ defmodule Goal.SyntaxTest do
 
   import Goal.Syntax
 
-  describe "define schema" do
+  describe "defschema/1" do
     test "valid example" do
       schema =
         defschema do

--- a/test/goal_test.exs
+++ b/test/goal_test.exs
@@ -1,6 +1,8 @@
 defmodule GoalTest do
   use ExUnit.Case
 
+  import Goal.Helpers
+
   describe "validate_params/2" do
     test "valid example" do
       data = %{
@@ -752,13 +754,33 @@ defmodule GoalTest do
                map_1: ["can't be blank"]
              }
     end
-  end
 
-  defp errors_on(changeset) do
-    Goal.traverse_errors(changeset, fn {message, opts} ->
-      Regex.replace(~r"%{(\w+)}", message, fn _map, key ->
-        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
-      end)
-    end)
+    test "works with atom-based maps" do
+      data = %{
+        map: %{
+          string: "hello",
+          integer: 5
+        }
+      }
+
+      schema = %{
+        map: [
+          type: :map,
+          properties: %{
+            string: [type: :string],
+            integer: [type: :integer]
+          }
+        ]
+      }
+
+      assert Goal.validate_params(data, schema) ==
+               {:ok,
+                %{
+                  map: %{
+                    string: "hello",
+                    integer: 5
+                  }
+                }}
+    end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,54 @@
 ExUnit.start()
+
+defmodule Goal.Helpers do
+  def errors_on(changeset) do
+    Goal.traverse_errors(changeset, fn {message, opts} ->
+      Regex.replace(~r"%{(\w+)}", message, fn _map, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+  end
+end
+
+defmodule Goal.DemoSchema do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Goal.EmbeddedDemoSchema
+
+  schema "demo" do
+    field(:name, :string)
+    field(:age, :integer)
+
+    embeds_one(:embedded_demo, EmbeddedDemoSchema)
+
+    timestamps()
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, [:name, :age])
+    |> cast_embed(:embedded_demo)
+    |> validate_required([:name, :age, :embedded_demo])
+  end
+end
+
+defmodule Goal.EmbeddedDemoSchema do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  embedded_schema do
+    field(:name, :string)
+    field(:age, :integer)
+
+    timestamps()
+  end
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:name, :age])
+    |> validate_required([:name, :age])
+  end
+end


### PR DESCRIPTION
- Add number validations for all number fields (e.g. `:decimal`, `:float`)
- Add tests to confirm `Goal.traverse_errors/2` doesn't break with Ecto schemas and embedded schemas
- Add test to confirm Goal works with atom-based maps.
- Bump version to `0.1.1`
- Improve the documentation