### PR TITLE
Fix recase_keys/3 when value isn't a map or list of maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.2
+
+No breaking changes.
+
+- Fixes a bug in `recase_keys/3` when it receives a value that isn't a map or list of maps
+
 # 0.2.1
 
 No breaking changes.

--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -725,7 +725,7 @@ defmodule Goal do
     Enum.reduce_while(map, false, fn {key, _value}, _acc -> {:halt, is_atom(key)} end)
   end
 
-  defp recase_keys(schema, params, from_case, is_atom_map) do
+  defp recase_keys(schema, params, from_case, is_atom_map) when is_map(params) do
     Enum.reduce(schema, %{}, fn {field, rules}, acc ->
       recased_field =
         field
@@ -745,7 +745,7 @@ defmodule Goal do
 
           is_list(value) ->
             inner_schema = Keyword.get(rules, :properties)
-            Enum.map(value, &recase_keys(inner_schema, &1, from_case, is_atom_map))
+            recase_keys(inner_schema, value, from_case, is_atom_map)
 
           true ->
             value
@@ -754,6 +754,12 @@ defmodule Goal do
       Map.put(acc, field, value)
     end)
   end
+
+  defp recase_keys(schema, value, from_case, is_atom_map) when is_list(value) do
+    Enum.map(value, &recase_keys(schema, &1, from_case, is_atom_map))
+  end
+
+  defp recase_keys(_schema, value, _from_case, _is_atom_map), do: value
 
   defp recase_string(string, :camel_case), do: Recase.to_camel(string)
   defp recase_string(string, :snake_case), do: Recase.to_snake(string)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Goal.MixProject do
   use Mix.Project
 
-  @version "0.2.1"
+  @version "0.2.2"
   @source_url "https://github.com/martinthenth/goal"
   @changelog_url "https://github.com/martinthenth/goal/blob/main/CHANGELOG.md"
 

--- a/test/goal_test.exs
+++ b/test/goal_test.exs
@@ -1231,5 +1231,28 @@ defmodule GoalTest do
                  preferences: [%{food_choice: "pizza", drink_choice: "cola"}]
                }
     end
+
+    test "list of strings" do
+      schema = %{
+        first_name: [type: :string],
+        last_name: [type: :string],
+        preferences: [type: {:array, :string}]
+      }
+
+      params = %{
+        "firstName" => "Jane",
+        "lastName" => "Doe",
+        "preferences" => ["pizza", "cola"]
+      }
+
+      opts = [recase_keys: [from: :camel_case]]
+
+      assert Goal.recase_keys(schema, params, opts) ==
+               %{
+                 first_name: "Jane",
+                 last_name: "Doe",
+                 preferences: ["pizza", "cola"]
+               }
+    end
   end
 end


### PR DESCRIPTION
Fixes a bug where `recase_keys/3` raises an error when receiving a value that isn't a map or a list of maps.