### PR TITLE
Add recase_keys/2 for recasing outbound parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 No breaking changes.
 
-- Fixes a bug in `recase_keys/3` when it receives a value that isn't a map or list of maps
+- Fixes a bug in `recase_keys/4` when it receives a value that isn't a map or list of maps
 
 # 0.2.1
 
 No breaking changes.
 
-- Adds `recase_keys/3` to recase parameter keys from `camelCase`, `snake_case`, `PascalCase` or `kebab-case`
+- Adds `recase_keys/4` to recase parameter keys from `camelCase`, `snake_case`, `PascalCase` or `kebab-case`
 - Adds optional `recase_keys` configuration to `validate/3` and `validate_params/3`
 - Adds optional `recase_keys` global configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.3
+
+No breaking changes.
+
+- Adds `recase_keys/2` for recasing outbound keys
+- Adds optional `:to_case` option to `:recase_keys` global configuration
+
 # 0.2.2
 
 No breaking changes.
@@ -8,9 +15,9 @@ No breaking changes.
 
 No breaking changes.
 
-- Adds `recase_keys/4` to recase parameter keys from `camelCase`, `snake_case`, `PascalCase` or `kebab-case`
-- Adds optional `recase_keys` configuration to `validate/3` and `validate_params/3`
-- Adds optional `recase_keys` global configuration
+- Adds `recase_keys/3` to recase parameter keys from `camelCase`, `snake_case`, `PascalCase` or `kebab-case`
+- Adds optional `:recase_keys` configuration to `validate/3` and `validate_params/3`
+- Adds optional `:recase_keys` global configuration
 
 # 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ The field types and available validations are:
 The default basic type is `:string`. You don't have to define this field if you are using the
 basic syntax.
 
-All field types, exluding `:map` and `{:array, :map}`, can use `:equals`, `:subset`,
+All field types, excluding `:map` and `{:array, :map}`, can use `:equals`, `:subset`,
 `:included`, `:excluded` validations.
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -134,34 +134,6 @@ iex(2)> MySchema.changeset(:show, %{id: "f86b1460-c2dc-4b7f-a28b-e3f21f3ebe7b"})
 
 ## Features
 
-### Recase keys
-
-By default, Goal will look for the keys defined in `defparams`. But sometimes frontend applications
-send parameters in a different format; for example, in `camelCase` but your backend uses
-`snake_case`. For this scenario, Goal has the `:recase_keys` option:
-
-```elixir
-config :goal,
-  recase_keys: [from: :camel_case]
-
-iex(1)> MySchema.validate(:show, %{"firstName" => "Jane"})
-{:ok, %{first_name: "Jane"}}
-```
-
-### Bring your own regex
-
-Goal has sensible defaults for string format validation. If you'd like to use your own regex,
-e.g. for validating email addresses or passwords, then you can add your own regex in the
-configuration:
-
-```elixir
-config :goal,
-  uuid_regex: ~r/^[[:alpha:]]+$/,
-  email_regex: ~r/^[[:alpha:]]+$/,
-  password_regex: ~r/^[[:alpha:]]+$/,
-  url_regex: ~r/^[[:alpha:]]+$/
-```
-
 ### Deeply nested maps
 
 Goal efficiently builds error changesets for nested maps, and has support for lists of nested
@@ -192,12 +164,72 @@ iex(1)> Goal.validate_params(schema(), params)
 Use `Goal.traverse_errors/2` to build readable errors. Phoenix by default uses
 `Ecto.Changeset.traverse_errors/2`, which works for embedded Ecto schemas but not for the plain
 nested maps used by Goal. Goal's `traverse_errors/2` is compatible with (embedded)
-`Ecto.Schema`s, so you don't have to make any changes to your existing logic.
+`Ecto.Schema`, so you don't have to make any changes to your existing logic.
 
 ```elixir
 def translate_errors(changeset) do
   Goal.traverse_errors(changeset, &translate_error/1)
 end
+```
+
+### Recasing inbound keys
+
+By default, Goal will look for the keys defined in `defparams`. But sometimes frontend applications
+send parameters in a different format. For example, in `camelCase` but your backend uses
+`snake_case`. For this scenario, Goal has the `:recase_keys` option:
+
+```elixir
+config :goal,
+  recase_keys: [from: :camel_case]
+
+iex(1)> MySchema.validate(:show, %{"firstName" => "Jane"})
+{:ok, %{first_name: "Jane"}}
+```
+
+### Recasing outbound keys
+
+Use `recase_keys/2` to recase outbound keys. For example, in your views:
+
+```elixir
+config :goal,
+  recase_keys: [to: :camel_case]
+
+defmodule MyAppWeb.UserJSON do
+  import Goal
+
+  def show(%{user: user}) do
+    %{data: %{first_name: user.first_name}}
+    |> recase_keys()
+  end
+
+  def error(%{changeset: changeset}) do
+    errors =
+      changeset
+      |> Goal.Changeset.traverse_errors(&translate_error/1)
+      |> recase_keys()
+
+    %{errors: errors}
+  end
+end
+
+iex(1)> UserJSON.show(%{user: %{first_name: "Jane"}})
+%{data: %{firstName: "Jane"}}
+iex(2)> UserJSON.error(%Ecto.Changeset{errors: [first_name: {"can't be blank", [validation: :required]}]})
+%{errors: %{firstName: ["can't be blank"]}}
+```
+
+### Bring your own regex
+
+Goal has sensible defaults for string format validation. If you'd like to use your own regex,
+e.g. for validating email addresses or passwords, then you can add your own regex in the
+configuration:
+
+```elixir
+config :goal,
+  uuid_regex: ~r/^[[:alpha:]]+$/,
+  email_regex: ~r/^[[:alpha:]]+$/,
+  password_regex: ~r/^[[:alpha:]]+$/,
+  url_regex: ~r/^[[:alpha:]]+$/
 ```
 
 ### Available validations

--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -276,7 +276,7 @@ defmodule Goal do
   The default basic type is `:string`. You don't have to define this field if you are using the
   basic syntax.
 
-  All field types, exluding `:map` and `{:array, :map}`, can use `:equals`, `:subset`,
+  All field types, excluding `:map` and `{:array, :map}`, can use `:equals`, `:subset`,
   `:included`, `:excluded` validations.
 
   ## Credits
@@ -509,7 +509,7 @@ defmodule Goal do
 
   ## Examples
 
-      iex> recase_keys(%{"firstName" => "Jane"}, recase_keys: [to: :camel_case])
+      iex> recase_keys(%{"first_name" => "Jane"}, recase_keys: [to: :camel_case])
       %{firstName: "Jane"}
 
   Supported are `:camel_case`, `:pascal_case`, `:kebab_case` and `:snake_case`.

--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -515,7 +515,7 @@ defmodule Goal do
   Supported are `:camel_case`, `:pascal_case`, `:kebab_case` and `:snake_case`.
   """
   @spec recase_keys(params(), opts()) :: params()
-  def recase_keys(params, opts) do
+  def recase_keys(params, opts \\ []) do
     settings = Keyword.get(opts, :recase_keys) || Application.get_env(:goal, :recase_keys)
 
     if settings do

--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -725,6 +725,8 @@ defmodule Goal do
     Enum.reduce_while(map, false, fn {key, _value}, _acc -> {:halt, is_atom(key)} end)
   end
 
+  defp recase_keys(_schema, value, _from_case, _is_atom_map) when is_struct(value), do: value
+
   defp recase_keys(schema, params, from_case, is_atom_map) when is_map(params) do
     Enum.reduce(schema, %{}, fn {field, rules}, acc ->
       recased_field =

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Goal.MixProject do
   use Mix.Project
 
-  @version "0.2.2"
+  @version "0.2.3"
   @source_url "https://github.com/martinthenth/goal"
   @changelog_url "https://github.com/martinthenth/goal/blob/main/CHANGELOG.md"
 

--- a/test/goal_test.exs
+++ b/test/goal_test.exs
@@ -1128,14 +1128,117 @@ defmodule GoalTest do
     end
   end
 
+  describe "recase_keys/2" do
+    test "to snake_case" do
+      params = %{firstName: "Jane", lastName: "Doe"}
+      opts = [recase_keys: [to: :snake_case]]
+
+      assert Goal.recase_keys(params, opts) == %{first_name: "Jane", last_name: "Doe"}
+    end
+
+    test "to camel_case" do
+      params = %{first_name: "Jane", last_name: "Doe"}
+      opts = [recase_keys: [to: :camel_case]]
+
+      assert Goal.recase_keys(params, opts) == %{firstName: "Jane", lastName: "Doe"}
+    end
+
+    test "to pascal_case" do
+      params = %{first_name: "Jane", last_name: "Doe"}
+      opts = [recase_keys: [to: :pascal_case]]
+
+      assert Goal.recase_keys(params, opts) == %{FirstName: "Jane", LastName: "Doe"}
+    end
+
+    test "to kebab_case" do
+      params = %{first_name: "Jane", last_name: "Doe"}
+      opts = [recase_keys: [to: :kebab_case]]
+
+      assert Goal.recase_keys(params, opts) == %{"first-name": "Jane", "last-name": "Doe"}
+    end
+
+    test "string-based map" do
+      params = %{"first_name" => "Jane", "last_name" => "Doe"}
+      opts = [recase_keys: [to: :camel_case]]
+
+      assert Goal.recase_keys(params, opts) == %{"firstName" => "Jane", "lastName" => "Doe"}
+    end
+
+    test "nested map" do
+      params = %{
+        first_name: "Jane",
+        last_name: "Doe",
+        preferences: %{food_choice: "pizza", drink_choice: "cola"}
+      }
+
+      opts = [recase_keys: [to: :camel_case]]
+
+      assert Goal.recase_keys(params, opts) == %{
+               firstName: "Jane",
+               lastName: "Doe",
+               preferences: %{foodChoice: "pizza", drinkChoice: "cola"}
+             }
+    end
+
+    test "list of maps" do
+      params = %{
+        first_name: "Jane",
+        last_name: "Doe",
+        preferences: [%{food_choice: "pizza", drink_choice: "cola"}]
+      }
+
+      opts = [recase_keys: [to: :camel_case]]
+
+      assert Goal.recase_keys(params, opts) == %{
+               firstName: "Jane",
+               lastName: "Doe",
+               preferences: [%{foodChoice: "pizza", drinkChoice: "cola"}]
+             }
+    end
+
+    test "list of string" do
+      params = %{
+        first_name: "Jane",
+        last_name: "Doe",
+        preferences: ["pizza", "cola"]
+      }
+
+      opts = [recase_keys: [to: :camel_case]]
+
+      assert Goal.recase_keys(params, opts) == %{
+               firstName: "Jane",
+               lastName: "Doe",
+               preferences: ["pizza", "cola"]
+             }
+    end
+
+    test "list of structs" do
+      struct = DateTime.utc_now()
+
+      params = %{
+        first_name: "Jane",
+        last_name: "Doe",
+        preferences: [struct, struct]
+      }
+
+      opts = [recase_keys: [to: :camel_case]]
+
+      assert Goal.recase_keys(params, opts) ==
+               %{
+                 firstName: "Jane",
+                 lastName: "Doe",
+                 preferences: [struct, struct]
+               }
+    end
+  end
+
   describe "recase_keys/3" do
     test "from snake_case" do
       schema = %{firstName: [type: :string], lastName: [type: :string]}
       params = %{"first_name" => "Jane", "last_name" => "Doe"}
       opts = [recase_keys: [from: :snake_case]]
 
-      assert Goal.recase_keys(schema, params, opts) ==
-               %{firstName: "Jane", lastName: "Doe"}
+      assert Goal.recase_keys(schema, params, opts) == %{firstName: "Jane", lastName: "Doe"}
     end
 
     test "from camel_case" do
@@ -1143,8 +1246,7 @@ defmodule GoalTest do
       params = %{"firstName" => "Jane", "lastName" => "Doe"}
       opts = [recase_keys: [from: :camel_case]]
 
-      assert Goal.recase_keys(schema, params, opts) ==
-               %{first_name: "Jane", last_name: "Doe"}
+      assert Goal.recase_keys(schema, params, opts) == %{first_name: "Jane", last_name: "Doe"}
     end
 
     test "from pascal_case" do
@@ -1152,8 +1254,7 @@ defmodule GoalTest do
       params = %{"FirstName" => "Jane", "LastName" => "Doe"}
       opts = [recase_keys: [from: :pascal_case]]
 
-      assert Goal.recase_keys(schema, params, opts) ==
-               %{first_name: "Jane", last_name: "Doe"}
+      assert Goal.recase_keys(schema, params, opts) == %{first_name: "Jane", last_name: "Doe"}
     end
 
     test "from kebab_case" do
@@ -1161,8 +1262,7 @@ defmodule GoalTest do
       params = %{"first-name" => "Jane", "last-name" => "Doe"}
       opts = [recase_keys: [from: :kebab_case]]
 
-      assert Goal.recase_keys(schema, params, opts) ==
-               %{first_name: "Jane", last_name: "Doe"}
+      assert Goal.recase_keys(schema, params, opts) == %{first_name: "Jane", last_name: "Doe"}
     end
 
     test "atom-based map" do
@@ -1170,8 +1270,7 @@ defmodule GoalTest do
       params = %{firstName: "Jane", lastName: "Doe"}
       opts = [recase_keys: [from: :camel_case]]
 
-      assert Goal.recase_keys(schema, params, opts) ==
-               %{first_name: "Jane", last_name: "Doe"}
+      assert Goal.recase_keys(schema, params, opts) == %{first_name: "Jane", last_name: "Doe"}
     end
 
     test "nested map" do
@@ -1278,6 +1377,14 @@ defmodule GoalTest do
                  last_name: "Doe",
                  preferences: [struct, struct]
                }
+    end
+
+    test "redundant fields" do
+      schema = %{firstName: [type: :string], lastName: [type: :string]}
+      params = %{"first_name" => "Jane", "last_name" => "Doe", "age" => 25}
+      opts = [recase_keys: [from: :snake_case]]
+
+      assert Goal.recase_keys(schema, params, opts) == %{firstName: "Jane", lastName: "Doe"}
     end
   end
 end

--- a/test/goal_test.exs
+++ b/test/goal_test.exs
@@ -1254,5 +1254,30 @@ defmodule GoalTest do
                  preferences: ["pizza", "cola"]
                }
     end
+
+    test "list of structs" do
+      schema = %{
+        first_name: [type: :string],
+        last_name: [type: :string],
+        preferences: [type: {:array, DateTime}]
+      }
+
+      struct = DateTime.utc_now()
+
+      params = %{
+        "firstName" => "Jane",
+        "lastName" => "Doe",
+        "preferences" => [struct, struct]
+      }
+
+      opts = [recase_keys: [from: :camel_case]]
+
+      assert Goal.recase_keys(schema, params, opts) ==
+               %{
+                 first_name: "Jane",
+                 last_name: "Doe",
+                 preferences: [struct, struct]
+               }
+    end
   end
 end


### PR DESCRIPTION
This PR adds the `recase_keys/2` function, which recases all keys in the given map. It can be used when the application has full control over a dataset, and should not be used for user requests.