### PR TITLE
Add fallback to non-recased keys for recase_keys/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ No breaking changes.
 
 - Adds `recase_keys/2` for recasing outbound keys
 - Adds optional `:to_case` option to `:recase_keys` global configuration
+- Adds fallback to non-recased parameters when recasing inbound parameters
 
 # 0.2.2
 

--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -834,12 +834,7 @@ defmodule Goal do
 
   defp recase_outbound_keys(params, to_case, is_atom_map) when is_map(params) do
     Enum.reduce(params, %{}, fn {key, value}, acc ->
-      value =
-        cond do
-          is_map(value) -> recase_outbound_keys(value, to_case, is_atom_map)
-          is_list(value) -> Enum.map(value, &recase_outbound_keys(&1, to_case, is_atom_map))
-          true -> value
-        end
+      value = recase_outbound_keys(value, to_case, is_atom_map)
 
       key = if is_atom(key), do: Atom.to_string(key), else: key
       key = recase_key(key, to_case)
@@ -847,6 +842,10 @@ defmodule Goal do
 
       Map.put(acc, key, value)
     end)
+  end
+
+  defp recase_outbound_keys(value, to_case, is_atom_map) when is_list(value) do
+    Enum.map(value, &recase_outbound_keys(&1, to_case, is_atom_map))
   end
 
   defp recase_outbound_keys(value, _to_case, _is_atom_map), do: value

--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -801,10 +801,10 @@ defmodule Goal do
         |> Atom.to_string()
         |> recase_key(from_case)
 
-      value =
-        if is_atom_map,
-          do: Map.get(params, String.to_atom(recased_field)),
-          else: Map.get(params, recased_field)
+      recased_field = if is_atom_map, do: String.to_atom(recased_field), else: recased_field
+      fallback_field = if is_atom_map, do: field, else: Atom.to_string(field)
+
+      value = Map.get(params, recased_field) || Map.get(params, fallback_field)
 
       value =
         cond do

--- a/test/goal_test.exs
+++ b/test/goal_test.exs
@@ -10,6 +10,7 @@ defmodule GoalTest do
 
   defparams :show do
     required(:id, :integer)
+    optional(:user_id, :integer)
     optional(:first_name, :string)
     optional(:last_name, :string)
   end
@@ -54,6 +55,7 @@ defmodule GoalTest do
     test "schema/1" do
       assert schema(:show) == %{
                id: [type: :integer, required: true],
+               user_id: [type: :integer],
                first_name: [type: :string],
                last_name: [type: :string]
              }
@@ -144,13 +146,10 @@ defmodule GoalTest do
 
       assert validate(:show, %{id: 123, firstName: "Jane", lastName: "Doe"},
                recase_keys: [from: :camel_case]
-             ) ==
-               {:ok,
-                %{
-                  id: 123,
-                  first_name: "Jane",
-                  last_name: "Doe"
-                }}
+             ) == {:ok, %{id: 123, first_name: "Jane", last_name: "Doe"}}
+
+      assert validate(:show, %{id: 123, user_id: 123}, recase_keys: [from: :camel_case]) ==
+               {:ok, %{id: 123, user_id: 123}}
     end
   end
 
@@ -177,6 +176,15 @@ defmodule GoalTest do
 
       assert Goal.validate_params(schema, data, opts) ==
                {:ok, %{first_name: "Jane", last_name: "Doe"}}
+    end
+
+    test "recase params falls back to defined keys" do
+      schema = %{user_id: [type: :integer], first_name: [type: :string]}
+      data = %{"user_id" => 123, "firstName" => "Jane"}
+      opts = [recase_keys: [from: :camel_case]]
+
+      assert Goal.validate_params(schema, data, opts) ==
+               {:ok, %{user_id: 123, first_name: "Jane"}}
     end
   end
 


### PR DESCRIPTION
I encountered an edge case where request body parameter keys were recased but the route path parameters (e.g. `/user/:user_id/profile`) were not recased. This PR adds a fallback to the non-recased keys for getting the parameters.