### PR TITLE
Fix bug where empty values were ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.4
+
+No breaking changes.
+
+- Fixes a bug with `recase_keys: [from: :camel_case]` where empty values were ignored
+
 # 0.2.3
 
 No breaking changes.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Goal.MixProject do
   use Mix.Project
 
-  @version "0.2.3"
+  @version "0.2.4"
   @source_url "https://github.com/martinthenth/goal"
   @changelog_url "https://github.com/martinthenth/goal/blob/main/CHANGELOG.md"
 

--- a/test/goal_test.exs
+++ b/test/goal_test.exs
@@ -186,6 +186,22 @@ defmodule GoalTest do
       assert Goal.validate_params(schema, data, opts) ==
                {:ok, %{user_id: 123, first_name: "Jane"}}
     end
+
+    test "includes empty values when they were given" do
+      schema = %{timestamp: [type: :utc_datetime]}
+      params = %{"timestamp" => nil}
+      opts = [recase_keys: [from: :camel_case]]
+
+      assert Goal.validate_params(schema, params, opts) == {:ok, %{timestamp: nil}}
+    end
+
+    test "excludes empty values when they were not given" do
+      schema = %{name: [type: :string]}
+      params = %{}
+      opts = [recase_keys: [from: :camel_case]]
+
+      assert Goal.validate_params(schema, params, opts) == {:ok, %{}}
+    end
   end
 
   describe "build_changeset/2" do
@@ -1133,6 +1149,24 @@ defmodule GoalTest do
                  integer: 5
                }
              }
+    end
+
+    test "includes empty values when they were given" do
+      schema = %{timestamp: [type: :utc_datetime]}
+      params = %{"timestamp" => nil}
+
+      changeset = Goal.build_changeset(schema, params)
+
+      assert changes_on(changeset) == %{timestamp: nil}
+    end
+
+    test "excludes empty values when they were not given" do
+      schema = %{name: [type: :string]}
+      params = %{}
+
+      changeset = Goal.build_changeset(schema, params)
+
+      assert changes_on(changeset) == %{}
     end
   end
 


### PR DESCRIPTION
Fixes a bug with `recase_keys: [from: :camel_case]` where empty values were ignored