### PR TITLE
Bump required Ecto version to 3.9

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Goal.MixProject do
 
   defp deps do
     [
-      {:ecto, "~> 3.7"},
+      {:ecto, "~> 3.9"},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:ex_doc, "~> 0.27", only: :dev, runtime: false},


### PR DESCRIPTION
Release `0.2.4` uses `force_changes: true` with `Ecto.Changeset.cast/4` to force empty values to be casted when using the `recase_keys` config option. `:force_changes` was introduced in Ecto `3.9` so Goal should require that version.