### PR TITLE
Fix bug with recasing inbound keys and empty map

### DIFF
--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -831,8 +831,9 @@ defmodule Goal do
 
   defp get_value(rules, params, field, from_case, is_atom_map) do
     value = Map.get(params, field)
+    schema = Keyword.get(rules, :properties)
 
-    if is_map(value) || is_list(value) do
+    if (is_map(value) || is_list(value)) && schema do
       rules
       |> Keyword.get(:properties)
       |> recase_inbound_keys(value, from_case, is_atom_map)

--- a/test/goal_test.exs
+++ b/test/goal_test.exs
@@ -1315,6 +1315,14 @@ defmodule GoalTest do
       assert Goal.recase_keys(schema, params, opts) == %{first_name: "Jane", last_name: "Doe"}
     end
 
+    test "map" do
+      schema = %{description: [type: :map, required: true]}
+      params = %{"description" => %{}}
+      opts = [recase_keys: [from: :camel_case]]
+
+      assert Goal.recase_keys(schema, params, opts) == %{description: %{}}
+    end
+
     test "nested map" do
       schema = %{
         first_name: [type: :string],


### PR DESCRIPTION
When using `recase_keys` for inbound parameters, the schema can define an empty map for schema rules. The recasing logic assumes there is always a schema, while the original logic does not. This raises an exception.