### PR TITLE
Allow any Regex in `:format` option

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.13.4-otp-24
+erlang 24.3.4.11

--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -732,6 +732,9 @@ defmodule Goal do
       {:format, :url}, acc ->
         validate_format(acc, field, Goal.Regex.url())
 
+      {:format, %Regex{} = regex}, acc ->
+        validate_format(acc, field, regex)
+
       {:less_than, integer}, acc ->
         validate_number(acc, field, less_than: integer)
 

--- a/test/goal_test.exs
+++ b/test/goal_test.exs
@@ -542,6 +542,19 @@ defmodule GoalTest do
       assert errors_on(changeset_2) == %{url: ["has invalid format"]}
     end
 
+    test "string, format: %Regex{}" do
+      schema = %{id: [type: :string, format: ~r/a-d0-5/i]}
+
+      data_1 = %{"id" => "ad41cb"}
+      data_2 = %{"id" => "zu981ik"}
+
+      changeset_1 = Goal.build_changeset(schema, data_1)
+      changeset_2 = Goal.build_changeset(schema, data_2)
+
+      assert changes_on(changeset_1) == %{id: "ad41cb"}
+      assert errors_on(changeset_2) == %{id: ["has invalid format"]}
+    end
+
     test "integer, is: 5" do
       schema = %{age: [type: :integer, is: 5]}
 


### PR DESCRIPTION
As discussed in #52, this allows passing any `%Regex{}` to the `:format` option, usually used on String types.

Let me know if there are additional test cases you'd like to see covered as well.