### PR TITLE
Add support for presence checks, and prepare version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,24 @@
-# 0.2.5
+# 0.3.0
 
-No breaking changes.
+- Adds support for validation on array items (https://github.com/martinthenth/goal/pull/50 - by [@LukasKnuth](https://github.com/LukasKnuth))
+- Adds support for Regex validation in `defparams` (https://github.com/martinthenth/goal/pull/53 - by [@LukasKnuth](https://github.com/LukasKnuth))
+- Adds the `:any` field type in `defparams`, enabling presence checks without validation
+- Fixes a bug with optional arrays of maps
+- Removes `defschema` in favor of `defparams`
+
+Migration instructions:
+
+1.  Replace `defschema` with `defparams` definitions
+
+# 0.2.5
 
 - Fixes a bug with recasing inbound keys when an empty map is given as parameter
 
 # 0.2.4
 
-No breaking changes.
-
 - Fixes a bug with `recase_keys: [from: :camel_case]` where empty values were ignored
 
 # 0.2.3
-
-No breaking changes.
 
 - Adds `recase_keys/2` for recasing outbound keys
 - Adds optional `:to_case` option to `:recase_keys` global configuration
@@ -20,21 +26,15 @@ No breaking changes.
 
 # 0.2.2
 
-No breaking changes.
-
 - Fixes a bug in `recase_keys/4` when it receives a value that isn't a map or list of maps
 
 # 0.2.1
-
-No breaking changes.
 
 - Adds `recase_keys/3` to recase parameter keys from `camelCase`, `snake_case`, `PascalCase` or `kebab-case`
 - Adds optional `:recase_keys` configuration to `validate/3` and `validate_params/3`
 - Adds optional `:recase_keys` global configuration
 
 # 0.2.0
-
-Breaking changes!
 
 - Adds new macros `defparams/1` and `defparams/2`
 - Adds `changeset/1` and `changeset/2` to build changesets from schemas defined with `defparams/2`.
@@ -53,21 +53,15 @@ See the docs for more information on the new `defparams` macro.
 
 # 0.1.3
 
-No breaking changes.
-
 - Exposes `build_changeset/2` in the main namespace (`Goal`)
 - Updates documentation for use with LiveViews
 
 # 0.1.2
 
-No breaking changes.
-
 - Adds `:uuid` type
 - Improves password regex to allow non-alphanumeric characters
 
 # 0.1.1
-
-No breaking changes.
 
 - Allow number validations for all number fields (incl. `:decimal`, `:float`)
 - Adds performance optimizations to the validation logic
@@ -76,8 +70,6 @@ No breaking changes.
 - Updates documentation
 
 # 0.1.0
-
-No breaking changes.
 
 - Adds `defschema` macro for defining validation schemas with less boilerplate
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,19 @@ end
 
 ## Features
 
+### Presence checks
+
+Sometimes all you need is to check if a parameter is present:
+
+```elixir
+use Goal
+
+defparams :show do
+  required :id
+  optional :query
+end
+```
+
 ### Deeply nested maps
 
 Goal efficiently builds error changesets for nested maps, and has support for lists of nested
@@ -153,7 +166,7 @@ maps. There is no limitation on depth.
 ```elixir
 use Goal
 
-defparams do
+defparams :show do
   optional :nested_map, :map do
     required :id, :integer
     optional :inner_map, :map do
@@ -166,7 +179,7 @@ defparams do
   end
 end
 
-iex(1)> Goal.validate_params(schema(), params)
+iex(1)> validate(:show, params)
 {:ok, %{nested_map: %{inner_map: %{map: %{id: 123, list: [1, 2, 3]}}}}}
 ```
 
@@ -299,9 +312,6 @@ The field types and available validations are:
 |                        | `:max`                      | maximum array length                                                                                 |
 |                        | `:is`                       | exact array length                                                                                   |
 | More basic types       |                             | See [Ecto.Schema](https://hexdocs.pm/ecto/Ecto.Schema.html#module-primitive-types) for the full list |
-
-The default basic type is `:string`. You don't have to define this field if you are using the
-basic syntax.
 
 All field types, excluding `:map` and `{:array, :map}`, can use `:equals`, `:subset`,
 `:included`, `:excluded` validations.

--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -397,34 +397,6 @@ defmodule Goal do
   end
 
   @doc """
-  A macro for defining validation schemas. Can be assigned to a variable.
-
-  ```elixir
-  import Goal
-
-  defp schema do
-    defschema do
-      required :id, :string, format: :uuid
-      required :name, :string
-      optional :age, :integer, min: 0, max: 120
-      optional :gender, :enum, values: ["female", "male", "non-binary"]
-
-      required :data, :map do
-        required :city, :string
-        optional :birthday, :date
-      end
-    end
-  end
-  ```
-  """
-  @spec defschema(do_block()) :: any
-  defmacro defschema(do: block) do
-    block
-    |> generate_schema()
-    |> Macro.escape()
-  end
-
-  @doc """
   A macro for defining validation schemas encapsulated in a `schema` function with arity 0.
 
   ```elixir

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Goal.MixProject do
   use Mix.Project
 
-  @version "0.2.5"
+  @version "0.3.0"
   @source_url "https://github.com/martinthenth/goal"
   @changelog_url "https://github.com/martinthenth/goal/blob/main/CHANGELOG.md"
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,9 +1,9 @@
 ExUnit.start()
 
 defmodule Goal.Helpers do
-  def changes_on(changeset), do: changeset.changes
+  def changes_on(%Ecto.Changeset{valid?: true} = changeset), do: changeset.changes
 
-  def errors_on(changeset) do
+  def errors_on(%Ecto.Changeset{valid?: false} = changeset) do
     Goal.traverse_errors(changeset, fn {message, opts} ->
       Regex.replace(~r"%{(\w+)}", message, fn _map, key ->
         opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()


### PR DESCRIPTION
- Adds the `:any` field type in `defparams`, enabling presence checks without validation
- Removes `defschema` in favor of `defparams`
- Adds explicit changeset pattern matching for testing convenience