### PR TITLE
Add support for recasing keys in changeset/3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.13.4-otp-24
-erlang 24.3.4.11
+erlang 25.1.2
+elixir 1.14.2-otp-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.1
+
+- Adds support for recasing inbound keys in `changeset/3`
+
 # 0.3.0
 
 - Adds support for validation on array items (https://github.com/martinthenth/goal/pull/50 - by [@LukasKnuth](https://github.com/LukasKnuth))

--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -376,10 +376,11 @@ defmodule Goal do
       Builds a changeset from the schema and params.
       """
       @spec changeset(name(), params()) :: changeset()
-      def changeset(name, params \\ %{}) do
-        name
-        |> schema()
-        |> build_changeset(params)
+      def changeset(name, params \\ %{}, opts \\ []) do
+        schema = schema(name)
+        params = recase_keys(schema, params, opts)
+
+        build_changeset(schema, params)
       end
 
       @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Goal.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.3.1"
   @source_url "https://github.com/martinthenth/goal"
   @changelog_url "https://github.com/martinthenth/goal/blob/main/CHANGELOG.md"
 

--- a/test/goal_test.exs
+++ b/test/goal_test.exs
@@ -142,6 +142,19 @@ defmodule GoalTest do
              } = changeset(:show, %{})
     end
 
+    test "changeset/3" do
+      assert %Ecto.Changeset{
+               action: nil,
+               changes: %{},
+               errors: [],
+               data: %{},
+               valid?: true
+             } =
+               changeset(:show, %{id: 123, any_1: 123, firstName: "Joan", lastName: "Of Arc"},
+                 recase_keys: [from: :camel_case]
+               )
+    end
+
     test "validate/3" do
       assert validate(:show, %{id: 123, any_1: 123}) == {:ok, %{id: 123, any_1: 123}}
 


### PR DESCRIPTION
I found a use-case where it's desired to build a `changeset` with `changeset/3` in a JSON API and later re-use the changeset to send an invalidated changeset back to the frontend. This change doesn't break any existing functionality.