### PR TITLE
Support custom regex for validation via config

### DIFF
--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -726,6 +726,9 @@ defmodule Goal do
       {:format, %Regex{} = regex}, acc ->
         validate_format(acc, field, regex)
 
+      {:format, key}, acc when is_atom(key) ->
+        validate_format(acc, field, Goal.Regex.custom(key))
+
       {:less_than, integer}, acc ->
         validate_number(acc, field, less_than: integer)
 

--- a/lib/goal/regex.ex
+++ b/lib/goal/regex.ex
@@ -38,4 +38,10 @@ defmodule Goal.Regex do
       ~r/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/
     )
   end
+
+  @doc false
+  @spec custom(atom()) :: Regex.t()
+  def custom(key) when is_atom(key) do
+    Application.get_env(:goal, String.to_atom("#{key}_regex"), nil)
+  end
 end

--- a/test/goal/regex_test.exs
+++ b/test/goal/regex_test.exs
@@ -116,4 +116,15 @@ defmodule Goal.RegexTest do
       Application.delete_env(:goal, :url_regex)
     end
   end
+
+  describe "custom/1" do
+    test "with a custom regex" do
+      Application.put_env(:goal, :custom_regex, ~r/^[[:alpha:]]+$/)
+
+      assert String.match?("abc", Regex.custom(:custom)) == true
+      assert String.match?("123", Regex.custom(:custom)) == false
+
+      Application.delete_env(:goal, :custom_regex)
+    end
+  end
 end

--- a/test/goal_test.exs
+++ b/test/goal_test.exs
@@ -24,6 +24,7 @@ defmodule GoalTest do
     optional(:type, :string, squish: true)
     optional(:age, :integer, min: 0, max: 120)
     optional(:gender, :enum, values: ["female", "male", "non-binary"])
+    optional(:hash, :string, format: :hash)
 
     required :car, :map do
       optional(:name, :string, min: 3, max: 20)
@@ -71,6 +72,7 @@ defmodule GoalTest do
                type: [type: :string, squish: true],
                age: [type: :integer, min: 0, max: 120],
                gender: [type: :enum, values: ["female", "male", "non-binary"]],
+               hash: [type: :string, format: :hash],
                car: [
                  type: :map,
                  required: true,
@@ -594,6 +596,24 @@ defmodule GoalTest do
 
       assert changes_on(changeset_1) == %{id: "ad41cb"}
       assert errors_on(changeset_2) == %{id: ["has invalid format"]}
+    end
+
+    test "string, format: custom regex" do
+      Application.put_env(:goal, :custom_regex, ~r/^[a-fA-F0-9]{40}$/)
+
+      schema = %{hash: [type: :string, format: :custom]}
+
+      hash =  :crypto.hash(:sha, "test") |> Base.encode16
+      data_1 = %{"hash" => hash}
+      data_2 = %{"hash" => "notahash"}
+
+      changeset_1 = Goal.build_changeset(schema, data_1)
+      changeset_2 = Goal.build_changeset(schema, data_2)
+
+      assert changes_on(changeset_1) == %{hash: hash}
+      assert errors_on(changeset_2) == %{hash: ["has invalid format"]}
+
+      Application.delete_env(:goal, :custom_regex)
     end
 
     test "integer, is: 5" do

--- a/test/goal_test.exs
+++ b/test/goal_test.exs
@@ -603,7 +603,7 @@ defmodule GoalTest do
 
       schema = %{hash: [type: :string, format: :custom]}
 
-      hash =  :crypto.hash(:sha, "test") |> Base.encode16
+      hash = :crypto.hash(:sha, "test") |> Base.encode16()
       data_1 = %{"hash" => hash}
       data_2 = %{"hash" => "notahash"}
 


### PR DESCRIPTION
Hello there!

I'm a user of this library, its been amazing so far. I love how declarative it is with macros!

However, in my [use case](https://github.com/lucca65/xrpl), I needed to run custom regex's, which are different from the default ones provided. 

I've changed it so those custom regex could live together with the customized `email`, `uuid`, in the Configuration. Maybe we could have another mechanism to send custom regex directly, but this use case is perfect for me since my regex's never change nor come from the client.

### Configure new regex

In the configuration file
```elixir
config :goal,
  # From Goal's docs
  uuid_regex: ~r/^[[:alpha:]]+$/,
  email_regex: ~r/^[[:alpha:]]+$/,

  # Custom regex used by my library
  ledger_index_regex: ~r/^(\d+|current|closed|validated)$/,
  ledger_entry_regex: ~r/^[a-fA-F0-9]{64}$/,
  currency_regex: ~r/^(?!(XRP$))[A-Za-z0-9\?\!\@\#\$\%\^\&\*\(\)\{\}\[\]\|]{3}$|^(?![0]{2})[A-Fa-f0-9]{40}$/,
  public_key_regex: ~r/^n[1-9a-np-zA-NP-Z]{1,53}$/,
  account_address_regex: ~r/^r[1-9a-np-zA-NP-Z]{24,34}$/
```

### Use it inside `defparams`:

```elixir
  defparams "account_nfts" do
    required(:account, :string, format: :account_address)
    optional(:ledger_hash, :string, format: :ledger_entry)
    optional(:ledger_index, :string, format: :ledger_index)
end
```

I think this is pretty and idiomatic, while keeping the same structure the library already have. 

Let me know your thoughts!