### PR TITLE
Fix bug where map without rules returns empty map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ erl_crash.dump
 *.beam
 /config/*.secret.exs
 .elixir_ls/
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1
+
+- Fixes a regression where `:map` without rules returns an empty map instead of the user's input (https://github.com/martinthenth/goal/issues/112).
+
 # 1.1.0
 
 - Adds support for enum arrays (https://github.com/martinthenth/goal/pull/107 - by [@davorbadrov](https://github.com/davorbadrov))

--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -570,7 +570,11 @@ defmodule Goal do
     quote do
       properties = Enum.reduce(unquote(children), %{}, &Map.merge(&2, &1))
 
-      %{unquote(name) => [{:type, unquote(type)} | [properties: properties]]}
+      if properties == %{} do
+        %{unquote(name) => [type: unquote(type)]}
+      else
+        %{unquote(name) => [type: unquote(type), properties: properties]}
+      end
     end
   end
 
@@ -594,9 +598,13 @@ defmodule Goal do
     quote do
       properties = Enum.reduce(unquote(children), %{}, &Map.merge(&2, &1))
 
-      %{
-        unquote(name) => [{:type, unquote(type)} | [{:required, true} | [properties: properties]]]
-      }
+      if properties == %{} do
+        %{unquote(name) => [type: unquote(type), required: true]}
+      else
+        %{
+          unquote(name) => [type: unquote(type), required: true, properties: properties]
+        }
+      end
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Goal.MixProject do
   use Mix.Project
 
-  @version "1.1.0"
+  @version "1.1.1"
   @source_url "https://github.com/martinthenth/goal"
   @changelog_url "https://github.com/martinthenth/goal/blob/main/CHANGELOG.md"
 


### PR DESCRIPTION
Solves https://github.com/martinthenth/goal/issues/112. A regression was introduced in https://github.com/martinthenth/goal/pull/93 because there was a test case missing in the original code to enforce the assumption that `properties` would not exist when not given in the DSL.