### PR TITLE
feat: add a `:custom` validation rule for application specific checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ The field types and available validations are:
 |                        | `:is`                       | exact string length                                                                                  |
 |                        | `:min`                      | minimum string length                                                                                |
 |                        | `:max`                      | maximum string length                                                                                |
-|                        | `:trim`                     | boolean to remove leading and trailing spaces                                                         |
+|                        | `:trim`                     | boolean to remove leading and trailing spaces                                                        |
 |                        | `:squish`                   | boolean to trim and collapse spaces                                                                  |
 |                        | `:format`                   | `:uuid`, `:email`, `:password`, `:url`                                                               |
 |                        | `:subset`                   | list of required strings                                                                             |
@@ -340,6 +340,7 @@ The field types and available validations are:
 |                        | `:max`                      | maximum array length                                                                                 |
 |                        | `:is`                       | exact array length                                                                                   |
 | More basic types       |                             | See [Ecto.Schema](https://hexdocs.pm/ecto/Ecto.Schema.html#module-primitive-types) for the full list |
+| Custom Validations     | `:custom`                   | expects a function taking a field name, params map, and a changeset, returning a changeset           |
 
 All field types, excluding `:map` and `{:array, :map}`, can use `:equals`, `:subset`,
 `:included`, `:excluded` validations.

--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -903,6 +903,12 @@ defmodule Goal do
       {:not_equal_to, integer}, acc ->
         validate_number(acc, field, not_equal_to: integer)
 
+      {:custom, custom_func}, acc when is_function(custom_func, 3) ->
+        case custom_func.(field, acc.changes, acc) do
+          %Changeset{} = changeset -> changeset
+          _ -> acc
+        end
+
       {_name, _setting}, acc ->
         acc
     end)

--- a/test/goal_test.exs
+++ b/test/goal_test.exs
@@ -75,6 +75,30 @@ defmodule GoalTest do
     optional(:name, :string, default: "The one who shall not be named")
   end
 
+  defparams :custom_validation do
+    optional(:is_home_address?, :boolean)
+    optional(:age, :integer)
+
+    optional(:address, :string,
+      custom: fn field, params, changeset ->
+        # Example "required if" validation case where the `address` is only required when
+        # both `age` and `is_home_address?` are present
+        case params do
+          %{age: _age, is_home_address?: _is_home_address?} ->
+            if Map.has_key?(params, field),
+              do:
+                Ecto.Changeset.add_error(changeset, field, """
+                is required when age and is_home_address? are present
+                """),
+              else: changeset
+
+          _ ->
+            changeset
+        end
+      end
+    )
+  end
+
   describe "__using__/1" do
     test "schema/0" do
       assert schema() == %{id: [type: :integer, required: true]}
@@ -169,6 +193,16 @@ defmodule GoalTest do
                data: %{},
                valid?: false
              } = changeset(:show)
+
+      custom_validation_params = %{address: "1201 Tokyo", age: 21, is_home_address?: true}
+
+      assert %Ecto.Changeset{
+               action: nil,
+               changes: ^custom_validation_params,
+               errors: [address: {"is required when age and is_home_address? are present\n", []}],
+               data: %{},
+               valid?: false
+             } = changeset(:custom_validation, custom_validation_params)
     end
 
     test "changeset/2" do


### PR DESCRIPTION
Adds a new `:custom` rule to give more control over what types of param validations you want which run `Goal` doesn't/shouldn't support when evaluating a param.

The proposed `:custom` opt takes a function which accpets the current field, the params map (changeset.changes), and current changeset and returns a changeset.


**Example:**
```elixir 
defparams :custom_validation do
  optional(:is_home_address?, :boolean)
  optional(:age, :integer)
  optional(:address, :string,
    custom: fn field, params, changeset ->
      # A simple "required if" validation case where the `address` is only required when
      # both `age` and `is_home_address?` fields are present in the params map
      case params do
        %{age: _age, is_home_address?: _is_home_address?} ->
          if Map.has_key?(params, field),
            do:
              Ecto.Changeset.add_error(changeset, field, """
              is required when age and is_home_address? are present
              """),
            else: changeset
        _ ->
          changeset
      end
    end
  )
end
```